### PR TITLE
Split static analyze commands in CI pipeline

### DIFF
--- a/.github/workflows/cicd-pipeline.yaml
+++ b/.github/workflows/cicd-pipeline.yaml
@@ -30,9 +30,23 @@ jobs:
       - name: Run Unit Tests
         run: make python-test-with-coverage
       
-      - name: Python Static Analyze
-        run: |
-          make python-static-analyze
+      - name: Run flake8
+        run: make flake8
+
+      - name: Run pylint
+        run: make pylint
+
+      - name: Run mypy
+        run: make mypy
+
+      - name: Run bandit
+        run: make bandit
+
+      - name: Run black-check
+        run: make black-check
+
+      - name: Run isrot-check
+        run: make isrot-check
 
   nodejs-ci:
     runs-on: ubuntu-latest
@@ -53,9 +67,14 @@ jobs:
         run: |
           npm install
 
-      - name: HTML, Markdown, NPM Static Analyze
-        run: |
-          make nodejs-static-analyze
+      - name: Run htmlhint
+        run: make htmlhint
+
+      - name: Run markdownlint
+        run: make markdownlint
+
+      - name: Run npm-audit
+        run: make npm-audit
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Split static analysis commands into separate steps in the CI pipeline.

* Replace the `Python Static Analyze` step in the `python-ci` job with individual steps for each static analysis command (`flake8`, `pylint`, `mypy`, `bandit`, `black-check`, `isrot-check`).
* Replace the `HTML, Markdown, NPM Static Analyze` step in the `nodejs-ci` job with individual steps for each static analysis command (`htmlhint`, `markdownlint`, `npm-audit`).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/f-kana/rh-tdd-workshop/pull/3?shareId=e68252b6-0739-4f9b-93cc-c74554bef737).